### PR TITLE
Support custom docker config home

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Following inputs can be used as `step.with` keys
 |---------------|---------|-----------|------------------------------------|
 | `version`     | String  | `latest`  | Buildx version. Example: `v0.3.0`  |
 
+### environment variables
+
+The following [official docker environment variables](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables) are supported:
+
+| Name            | Type    | Default      | Description                                    |
+|-----------------|---------|-------------|-------------------------------------------------|
+| `DOCKER_CONFIG` | String  | `~/.docker` | The location of your client configuration files |
+
 ### outputs
 
 Following outputs are available

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -1,14 +1,30 @@
 import fs = require('fs');
 import * as installer from '../src/installer';
+import * as path from "path";
+import * as os from "os";
 
 describe('installer', () => {
   it('acquires v0.2.2 version of buildx', async () => {
-    const buildx = await installer.getBuildx('v0.2.2');
+    const buildx = await installer.getBuildx('v0.2.2', path.join(os.homedir(), '.docker'));
     expect(fs.existsSync(buildx)).toBe(true);
   }, 100000);
 
   it('acquires latest version of buildx', async () => {
-    const buildx = await installer.getBuildx('latest');
+    const buildx = await installer.getBuildx('latest', path.join(os.homedir(), '.docker'));
     expect(fs.existsSync(buildx)).toBe(true);
+  }, 100000);
+
+  it('installs buildx in custom docker config home', async () => {
+    // Arrange
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghaction-docker-buildx-'));
+    console.log(tmpDir);
+
+    // Act
+    await installer.getBuildx('latest', tmpDir);
+
+    // Assert
+    expect(fs.existsSync(
+      path.join(tmpDir, 'cli-plugins', 'docker-buildx')
+    )).toBe(true);
   }, 100000);
 });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -8,13 +8,13 @@ import * as exec from '@actions/exec';
 
 let osPlat: string = os.platform();
 
-export async function getBuildx(version: string): Promise<string> {
+export async function getBuildx(version: string, dockerConfigHome: string): Promise<string> {
   const selected = await determineVersion(version);
   if (selected) {
     version = selected;
   }
 
-  const cliPluginsDir = path.join(os.homedir(), '.docker', 'cli-plugins');
+  const cliPluginsDir = path.join(dockerConfigHome, 'cli-plugins');
   const pluginName = osPlat == 'win32' ? 'docker-buildx.exe' : 'docker-buildx';
   const downloadUrl = util.format(
     'https://github.com/docker/buildx/releases/download/%s/%s',
@@ -30,12 +30,6 @@ export async function getBuildx(version: string): Promise<string> {
   }
 
   return path.join(cliPluginsDir, pluginName);
-}
-
-function getCliPluginsDir(): string {
-  const cliPluginsPath = path.join(os.homedir(), '.docker', 'cli-plugins');
-  fs.mkdirSync(cliPluginsPath, {recursive: true});
-  return cliPluginsPath;
 }
 
 function getFileName(version: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
 import * as stateHelper from './state-helper';
+import path from "path";
 
 async function run() {
   try {
@@ -14,7 +15,8 @@ async function run() {
     }
 
     const version = core.getInput('version') || 'latest';
-    await installer.getBuildx(version);
+    const dockerConfigHome: string = process.env.DOCKER_CONFIG || path.join(os.homedir(), '.docker');
+    await installer.getBuildx(version, dockerConfigHome);
 
     console.log('🐳 Docker info...');
     await exec.exec('docker', ['info']);


### PR DESCRIPTION
## Description

Fixes https://github.com/crazy-max/ghaction-docker-buildx/issues/155.

Add support for custom docker config home via the official client environment variable `DOCKER_CONFIG`.

## Todo

- [x] Write failing test with `DOCKER_CONFIG`
- [x] Add `DOCKER_CONFIG` support
- [x] All tests are green
- [x] Add documentation
- [x] Test in real conditions